### PR TITLE
Fixed: Unable to display unicode characters on Script Editor

### DIFF
--- a/Radegast/Core/Types/RRichTextBox.cs
+++ b/Radegast/Core/Types/RRichTextBox.cs
@@ -180,7 +180,7 @@ namespace Radegast
         #region Syntax highligting
         private string rtfEscaped(string s)
         {
-            return s.Replace(@"\", @"\\").Replace("{", @"\{").Replace("}", @"\}").Replace("\n", "\\par\n");
+            return RtfUnicode(s.Replace(@"\", @"\\").Replace("{", @"\{").Replace("}", @"\}").Replace("\n", "\\par\n"));
         }
 
         public Color CommentColor = Color.FromArgb(204, 76, 38);


### PR DESCRIPTION
- Fixed: Unable to display unicode characters on Script Editor

RAD-481 Script editor can not use Japanese character
https://metaverse.atlassian.net/browse/RAD-481