### PR TITLE
UDP inventory is deprecated as of 2015-03-30 and no longer supported on SecondLife platforms.

### DIFF
--- a/Radegast/GUI/Consoles/Inventory/InventoryConsole.cs
+++ b/Radegast/GUI/Consoles/Inventory/InventoryConsole.cs
@@ -793,7 +793,7 @@ namespace Radegast
                 if (QueuedFolders.Count == 0) break;
                 Logger.DebugLog(string.Format("Queued {0} folders for update", QueuedFolders.Count));
 
-                Parallel.ForEach<UUID>(Math.Min(QueuedFolders.Count, 6), QueuedFolders, folderID =>
+                System.Threading.Tasks.Parallel.ForEach<UUID>(QueuedFolders, folderID =>
                 {
                     bool success = false;
 

--- a/Radegast/GUI/Consoles/LoginConsole.cs
+++ b/Radegast/GUI/Consoles/LoginConsole.cs
@@ -474,9 +474,15 @@ namespace Radegast
             if (netcom.LoginOptions.Grid.Platform != "SecondLife")
             {
                 instance.Client.Settings.MULTIPLE_SIMS = true;
+                instance.Client.Settings.HTTP_INVENTORY = !instance.GlobalSettings["disable_http_inventory"];
+            }
+            else
+            {
+                // UDP inventory is deprecated as of 2015-03-30 and no longer supported.
+                // https://community.secondlife.com/t5/Second-Life-Server/Deploy-for-the-week-of-2015-03-30/td-p/2919194
+                instance.Client.Settings.HTTP_INVENTORY = true;
             }
 
-            instance.Client.Settings.HTTP_INVENTORY = !instance.GlobalSettings["disable_http_inventory"];
             netcom.Login();
             SaveConfig();
         }

--- a/Radegast/GUI/Dialogs/Settings.cs
+++ b/Radegast/GUI/Dialogs/Settings.cs
@@ -147,7 +147,7 @@ namespace Radegast
 
             if (!s.ContainsKey("disable_http_inventory"))
             {
-                s["disable_http_inventory"] = mono;
+                s["disable_http_inventory"] = false;
             }
 
             if (!s.ContainsKey("on_script_question"))


### PR DESCRIPTION
Fixed unsafe call of libomv parallel.foreach an defaulting to use http inventory (udp inventory response doesn't seem to work)