### PR TITLE
Fix for long passwords not saving correctly

### DIFF
--- a/Radegast/GUI/Consoles/LoginConsole.cs
+++ b/Radegast/GUI/Consoles/LoginConsole.cs
@@ -156,8 +156,16 @@ namespace Radegast
                 }
                 else
                 {
-                    sl.Password =Utils.MD5(txtPassword.Text);
-                    s["password"] = Utils.MD5(txtPassword.Text);
+                    if (txtPassword.Text > 16)
+                    {
+                        sl.Password = Utils.MD5(txtPassword.Text.Substring(0, 16));
+                        s["password"] = Utils.MD5(txtPassword.Text.Substring(0, 16));
+                    }
+                    else
+                    {
+                        sl.Password = Utils.MD5(txtPassword.Text);
+                        s["password"] = Utils.MD5(txtPassword.Text);
+                    }
                 }
                 if (cbxLocation.SelectedIndex == -1)
                 {


### PR DESCRIPTION
Login() method in RadegastNetcom properly trims password to 16 characters before logging in, but the password save code did not account for this.

Fix for:
https://radegast.life/bugs/saved-passwords-do-not-decrypt/
https://radegast.life/bugs/i-changed-my-sl-password-and-i-cannot-get-radegast-to-remember-the-new-password/
https://radegast.life/bugs/i-changed-my-sl-password-and-i-cannot-get-radegast-to-remember-the-new-password-2/